### PR TITLE
node-rdiff 0.0.3 can't build with librsync >= 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ http://linux.die.net/man/1/rdiff
 
 ## pre
 
-install librsync
+install librsync `~0.9.7`
 
 ## example
 


### PR DESCRIPTION
With librsync 1.0.0, node-gyp gives this error:

  CXX(target) Release/obj.target/rdiff/rdiff.o
../rdiff.cc: In function 'rs_result signature(const char_, const char_)':
../rdiff.cc:214:75: error: cannot convert 'rs_stats_t\* {aka rs_stats_}' to 'rs_magic_number' for argument '5' to 'rs_result rs_sig_file(FILE_, FILE_, size_t, size_t, rs_magic_number, rs_stats_t_)'
   result = rs_sig_file(basis_file, sig_file, block_len, strong_len, &stats);
                                                                           ^
rdiff.target.mk:83: recipe for target 'Release/obj.target/rdiff/rdiff.o' failed
make: **\* [Release/obj.target/rdiff/rdiff.o] Error 1
